### PR TITLE
Adding !prog, a progression graph command

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import discord
 import yaml
 
-from funct import best, get_help, recent, profile, register, ptt_recommendation, session_generator
+from funct import best, get_help, recent, profile, register, ptt_recommendation, session_generator, progression
 from art import get_random_tweet
 from leaderboard import leaderboard
 
@@ -34,6 +34,8 @@ class MyClient(discord.Client):
                     await register(message)
                 if message.content.startswith("!leaderboard"):
                     await leaderboard(message)
+                if message.content.startswith("!prog"):
+                    await progression(message)
 
         except OSError:
             msg_emb = discord.Embed(title="Erreur", type="rich", color=discord.Color.dark_red())

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ discord.py==1.6.0
 pyyaml==5.4.1
 aiosqlite==0.16.1
 https://files.pythonhosted.org/packages/ce/7e/0c71ba865ff6a3c38830afc25910a5e00345e054d836c92964f12f88d02c/Arc_api-1.1.tar.gz
+matplotlib==3.3.4


### PR DESCRIPTION
This command generates a PTT progression graph, directly inspired by redive's graph.

It uses the "rating_records" elements returned by ArcAPI, and generates the graph using matplotlib. It then save the figure in a BytesIO object used by discord to be sent as a file.

Below is an example of the results : 

![image](https://user-images.githubusercontent.com/35744239/112467711-aee01100-8d67-11eb-9b2f-246ceb99d142.png)
